### PR TITLE
fix missing calls to initialize_logging in entry points

### DIFF
--- a/conda/cli/activate.py
+++ b/conda/cli/activate.py
@@ -9,6 +9,7 @@ import sys
 from ..common.compat import ensure_text_type, on_win, text_type
 from ..exceptions import (ArgumentError, CondaEnvironmentError, CondaSystemExit, CondaValueError,
                           TooFewArgumentsError, TooManyArgumentsError)
+from ..gateways import initialize_logging
 from ..utils import shells
 
 
@@ -107,6 +108,8 @@ def get_activate_path(prefix, shell):
 
 def main():
     from ..base.constants import ROOT_ENV_NAME
+
+    initialize_logging()
 
     sys_argv = tuple(ensure_text_type(s) for s in sys.argv)
 

--- a/conda/cli/main.py
+++ b/conda/cli/main.py
@@ -43,6 +43,7 @@ from argparse import SUPPRESS
 from logging import CRITICAL, DEBUG, getLogger
 
 from .. import __version__
+from ..gateways import initialize_logging
 
 log = getLogger(__name__)
 
@@ -153,6 +154,7 @@ def _ensure_text_type(value):
 
 
 def main(*args):
+    initialize_logging()
     if not args:
         args = sys.argv
 

--- a/conda/cli/python_api.py
+++ b/conda/cli/python_api.py
@@ -13,7 +13,6 @@ from ..common.path import win_path_double_escape
 from ..exceptions import conda_exception_handler
 from ..gateways import initialize_std_loggers
 
-initialize_std_loggers()
 log = getLogger(__name__)
 
 
@@ -57,6 +56,7 @@ def run_command(command, *arguments, **kwargs):
 
 
     """
+    initialize_std_loggers()
     use_exception_handler = kwargs.get('use_exception_handler', False)
     configuration_search_path = kwargs.get('search_path', SEARCH_PATH)
     p, sub_parsers = generate_parser()

--- a/conda_env/cli/main.py
+++ b/conda_env/cli/main.py
@@ -7,6 +7,7 @@ from conda.base.constants import SEARCH_PATH
 from conda.base.context import context
 from conda.cli.conda_argparse import ArgumentParser
 from conda.cli.main import init_loggers
+from conda.gateways import initialize_logging
 
 try:
     from conda.exceptions import conda_exception_handler
@@ -67,6 +68,7 @@ def create_parser():
 
 
 def main():
+    initialize_logging()
     parser = create_parser()
     args = parser.parse_args()
     context.__init__(SEARCH_PATH, 'conda', args)


### PR DESCRIPTION
Oh well, that was dumb: in the last commit I removed the call to `initialize_logging` in `gateways/__init__.py` but did not add substituting explicit calls where needed!
This would be in `conda/cli/main.py`, `conda/cli/activate.py` and `conda_env/cli/main.py`, I guess.
Also the call to `initialize_std_loggers` in `conda/cli/python_api.py` can be moved into `run_command`.
Both these changes are included in this PR.

Are there any more entry points (which are not used for testing) that I missed? (Didn't see any while "grep-ing" for `__main__`...)